### PR TITLE
SignatureDoesNotMatch bug fixed.

### DIFF
--- a/aliyunauth/oss.py
+++ b/aliyunauth/oss.py
@@ -151,6 +151,8 @@ class OssAuth(requests.auth.AuthBase):
         }
 
         oss_url.forge(key=lambda x: x[0])
+        if canonicalized_headers:
+            canonicalized_headers = '{0}\n'.format(canonicalized_headers)
         canonicalized_str = "{0}/{1}".format(
             canonicalized_headers, os.path.join(self._bucket + oss_url.uri)
         )


### PR DESCRIPTION
I had a SignatureDoesNotMatch error when I put object to OSS with requests-aliyun.

This is my sign string.
```
PUT
AAAAAAAAAAAAA==
image/jpeg
Fri, 24 Mar 2017 10:37:29 GMT
x-oss-object-acl:private/redice-test/test.jpg
```

And I received below error.
```
<StringToSign>PUT
AAAAAAAAAAAAA==
image/jpeg
Fri, 24 Mar 2017 10:31:35 GMT
x-oss-object-acl:private
/redice-test/test.jpg</StringToSign>
```