### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,11 +14,11 @@ v0.3.1
 .. image:: https://requires.io/github/SkyLothar/requests-aliyun/requirements.svg?branch=master
     :target: https://requires.io/github/SkyLothar/requests-aliyun/requirements/?branch=master
 
-.. image:: https://pypip.in/py_versions/requests-aliyun/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/pyversions/requests-aliyun.svg?style=flat
     :target: https://pypi.python.org/pypi/requests-aliyun/
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/license/requests-aliyun/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/l/requests-aliyun.svg?style=flat
     :target: https://pypi.python.org/pypi/requests-aliyun/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20requests-aliyun))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `requests-aliyun`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.